### PR TITLE
fix: using active states extent for transitions

### DIFF
--- a/src/main/kotlin/at/ac/uibk/dps/cirrina/execution/object/StateMachine.kt
+++ b/src/main/kotlin/at/ac/uibk/dps/cirrina/execution/object/StateMachine.kt
@@ -139,9 +139,11 @@ internal constructor(
     if (candidates.isEmpty()) return null
 
     val evalExtent =
-      extent.extend(
-        ContextInMemory().apply { event.data.forEach { create(VAR_PREFIX + it.name, it.value) } }
-      )
+      activeState!!
+        .extent
+        .extend(
+          ContextInMemory().apply { event.data.forEach { create(VAR_PREFIX + it.name, it.value) } }
+        )
 
     return trySelect(candidates, evalExtent)?.also {
       event.data.forEach { d -> extent.setOrCreate(VAR_PREFIX + d.name, d.value) }
@@ -227,7 +229,7 @@ internal constructor(
   private fun doTransition(transition: Transition, event: Event?) =
     Observation.createNotStarted("stateMachine.transition", observationRegistry).observe {
       if (!transition.isOr) {
-        execute(transition.getActionCommands(createContext(this, event)))
+        execute(transition.getActionCommands(createContext(activeState!!, event)))
       }
     }
 


### PR DESCRIPTION
# Pull Request

<!--
Please make sure to have read the CONTRIBUTING.md guidelines.
-->

## Description

Fixing issue were active states extent was not considered for evaluating transitions and executing transition actions

## Type of change

<!--
Please delete options that are not relevant.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

All tests pass.

<!--
## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
-->