### PR TITLE
fix: removing event latency measurement for internal events

### DIFF
--- a/src/main/kotlin/at/ac/uibk/dps/cirrina/execution/object/StateMachine.kt
+++ b/src/main/kotlin/at/ac/uibk/dps/cirrina/execution/object/StateMachine.kt
@@ -136,7 +136,7 @@ internal constructor(
   private fun processEvent(event: Event) {
     if (isTerminated()) return
 
-    eventTimer.update((System.nanoTime() - event.emittedTime) / 1_000, TimeUnit.MICROSECONDS)
+    recordLatency(event)
 
     handleEvent(event)?.let { transition -> step(transition) }
 
@@ -257,6 +257,14 @@ internal constructor(
   }
 
   private fun stopTimeout(name: String) = timeoutActionManager.stop(name)
+
+  private fun recordLatency(event: Event) {
+    if (event.source == name) return
+    if (event.target != name) return
+    if (event.emittedTime == 0L) return
+
+    eventTimer.update((System.nanoTime() - event.emittedTime) / 1_000, TimeUnit.MICROSECONDS)
+  }
 
   override fun toString() = "StateMachine(name='$name')"
 


### PR DESCRIPTION
# Pull Request

<!--
Please make sure to have read the CONTRIBUTING.md guidelines.
-->

## Description

Event latency no longer considers internal events, and events with default emit time. 

## Type of change

<!--
Please delete options that are not relevant.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
-->

All tests pass.

<!--
## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
-->