### PR TITLE
fix: changing event timer to use currentTimeMillis instead of nanotime

### DIFF
--- a/src/main/kotlin/at/ac/uibk/dps/cirrina/execution/object/StateMachine.kt
+++ b/src/main/kotlin/at/ac/uibk/dps/cirrina/execution/object/StateMachine.kt
@@ -289,14 +289,14 @@ internal constructor(
     if (event.target != name) return
     if (event.emittedTime == 0L) return
 
-    eventTimer.update((System.nanoTime() - event.emittedTime) / 1_000, TimeUnit.MICROSECONDS)
+    eventTimer.update((System.currentTimeMillis() - event.emittedTime), TimeUnit.MILLISECONDS)
   }
 
   override fun toString() = "StateMachine(name='$name')"
 
   inner class StateMachineEventHandler(val eventHandler: EventHandler) {
     fun emit(event: Event) =
-      eventHandler.emit(event.copy(source = name, emittedTime = System.nanoTime()))
+      eventHandler.emit(event.copy(source = name, emittedTime = System.currentTimeMillis()))
 
     fun propagateToParent(event: Event) {
       parent?.stateMachineEventHandler?.propagateToParent(event) ?: pushEvent(event)


### PR DESCRIPTION
# Pull Request

<!--
Please make sure to have read the CONTRIBUTING.md guidelines.
-->

## Description

System.nanoTime() does not work across different machines. Thus it has been changed to currentTimeMillis

## Type of change

<!--
Please delete options that are not relevant.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
-->

All tests pass.

<!--
## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
-->