### PR TITLE
fix: removing consideration of own external events in event time capture

### DIFF
--- a/src/main/kotlin/at/ac/uibk/dps/cirrina/execution/object/StateMachine.kt
+++ b/src/main/kotlin/at/ac/uibk/dps/cirrina/execution/object/StateMachine.kt
@@ -156,7 +156,7 @@ internal constructor(
   private fun processEvent(event: Event) {
     if (isTerminated()) return
 
-    if (event.channel == EventChannel.EXTERNAL) {
+    if (event.channel == EventChannel.EXTERNAL && event.source != name) {
       val now = Clock.System.now()
       val nowNanos = (now.epochSeconds * 1_000_000_000L) + now.nanosecondsOfSecond
       val deltaNanos = (nowNanos - event.emittedTime).coerceAtLeast(0L)


### PR DESCRIPTION
# Pull Request

<!--
Please make sure to have read the CONTRIBUTING.md guidelines.
-->

## Description

A state machines own external events are no longer considered for event timer.

## Type of change

<!--
Please delete options that are not relevant.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
-->

All tests pass.

<!--
## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
-->