### PR TITLE
fix: resolving duplicate event subscriptions

### DIFF
--- a/src/main/kotlin/at/ac/uibk/dps/cirrina/Runtime.kt
+++ b/src/main/kotlin/at/ac/uibk/dps/cirrina/Runtime.kt
@@ -3,11 +3,7 @@ package at.ac.uibk.dps.cirrina
 import at.ac.uibk.dps.cirrina.cirrina.di.Main
 import at.ac.uibk.dps.cirrina.cirrina.di.Run
 import at.ac.uibk.dps.cirrina.execution.graph.EventGraph
-import at.ac.uibk.dps.cirrina.execution.`object`.Context
-import at.ac.uibk.dps.cirrina.execution.`object`.EventHandler
-import at.ac.uibk.dps.cirrina.execution.`object`.Extent
-import at.ac.uibk.dps.cirrina.execution.`object`.StateMachine
-import at.ac.uibk.dps.cirrina.execution.`object`.createHierarchy
+import at.ac.uibk.dps.cirrina.execution.`object`.*
 import at.ac.uibk.dps.cirrina.execution.service.RandomServiceImplementationSelector
 import at.ac.uibk.dps.cirrina.execution.service.ServiceImplementation
 import at.ac.uibk.dps.cirrina.execution.service.ServiceImplementationSelector
@@ -84,7 +80,7 @@ constructor(
     eventHandler.bind(
       graph = graph,
       instanceNames = run,
-      subscribedTo = instances.values.flatMap { it.subscriptions } /*.toSet()*/,
+      subscribedTo = instances.values.flatMap { it.subscriptions }.toSet(),
       handlers = instances.values.map { it::pushEvent },
     )
   }

--- a/src/test/resources/pkl/loop/main.pkl
+++ b/src/test/resources/pkl/loop/main.pkl
@@ -31,7 +31,7 @@ collaborativeStateMachine {
         }
         ["b"] {
           entry {
-            new Eval { expression = "v =+ 1" }
+            new Eval { expression = "v += 1" }
           }
           always {
             new Transition { to = "a"; provided = "v < 1000" }


### PR DESCRIPTION
# Pull Request

<!--
Please make sure to have read the CONTRIBUTING.md guidelines.
-->

## Description

The subscribers for events from each source (instance) were being created based on a list of instances' subscriptions. This lead to duplicate subscriptions (n, where n = number of scheduled instances in the runtime) and thereby delivery of duplicate events to state machines. Converted the list to a set to eliminate duplicate subscribers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Using existing unit and integration tests. Also added a new test to check that duplicate event delivery is prevented.

All tests pass.

<!--
## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
-->